### PR TITLE
Fixes #3: remove webconfigurator.xml dead reference

### DIFF
--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -6,10 +6,6 @@ _profiler:
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
     prefix:   /_profiler
 
-_configurator:
-    resource: "@SensioDistributionBundle/Resources/config/routing/webconfigurator.xml"
-    prefix:   /_configurator
-
 _errors:
     resource: "@TwigBundle/Resources/config/routing/errors.xml"
     prefix:   /_error


### PR DESCRIPTION
It was removed from version 5, and version 5 is required in the composer file

reference: https://github.com/sensiolabs/SensioDistributionBundle/commits/master/Resources/config/routing/webconfigurator.xml

Thanks and keep up the good work.